### PR TITLE
Minor update: exceptions for no argument, and infinite loop in SortNodeByNetOrder

### DIFF
--- a/src/bFlowNet/bFlowNet.cpp
+++ b/src/bFlowNet/bFlowNet.cpp
@@ -355,10 +355,15 @@ void bFlowNet::SortNodesByNetOrder()
         done = false;
       }
     }
-      
+
     nUnsortedNodes -= nThisPass;
 
-    // Reset all active node tracers to value 1
+      if((nThisPass ==  0) & (nUnsortedNodes>0)) {
+          throw runtime_error("No more tracers identified, but unsortedNodes remain.\n Check Points File");
+      }
+
+
+      // Reset all active node tracers to value 1
     for (listIter = nodeList->begin(); 
          listIter != nodeList->getLastActive(); listIter++) {
          (*listIter)->ActivateSortTracer();
@@ -2308,7 +2313,7 @@ void bFlowNet::SortStreamNodes()
     nStreams -= nThisPass;
 
     // Reset all active node tracers to value 1
-    for (streamIter == streamList.begin();
+    for (streamIter = streamList.begin();
          streamIter != streamList.end(); streamIter++) {
          (*streamIter)->ActivateSortTracer();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,11 +26,29 @@ int main( int argc, char **argv )
     using std::endl;
   #endif
 
+    if (argc < 2) {
+        // No arguments provided, print an error message
+        cerr << "Error: No input file provided." << endl;
+        return 1; // Return an error code
+    }
+
+
   // Check command-line arguments
   bInputFile InputFile(argv[1]);
   cout << "Reading input file " << argv[1] << endl;
 
-  bMeshBuilder MeshBuilder(InputFile);
+    try {
+        // Call the function to process the input file
+        bMeshBuilder MeshBuilder(InputFile);
+
+        // Continue with the rest of your code
+    } catch (const exception& e) {
+        // Handle the exception (print an error message, etc.)
+        std::cerr << "Error: " << e.what() << std::endl;
+        return 1; // Return an error code
+    }
+
+
 
   cout<<"\n\nPart 9: Deleting Objects and Exiting Program"<<endl;
   cout<<"------------------------------------------------"<<endl<<endl;


### PR DESCRIPTION
Added catch for (1) no argument provided, and (2) exception for SortNodeByNetOrder where it can get stuck in an infinite loop. Lastly, fixed warning about missuse of ==