### PR TITLE
Add support for reading and processing of pre-generated 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cmake-build-debug*
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cmake-build-debug*
 build/
+.vscode/settings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(
         src/bMeshElements/bMeshElements.cpp
         src/bMesh/bTriangulator.h
         src/bMesh/bTriangulator.cpp
+        src/bListInputData/bListInputData.h
 #
         src/bMesh/heapsort.h
         src/bMeshList/bMeshList.h

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cmake --build path/to/build/directory --target all
 Additional information on working with CMake is available on the tRIBS documentation [page](https://tribshms.readthedocs.io/en/latest/man/Model_Execution.html#cmake).
 
 ## Working with MeshBuilder
-MeshBuilder requires a .in file, similar to tRIBS, with at least the keywords:__POINTFILENAME__ and __OUTFILENAME__ provided. __OPTMESHINPUT__ should also be set to option 9. MeshBuilder can be run via the command line as follows.:
+MeshBuilder requires a .in file, similar to tRIBS, with at least the keywords:__OUTFILENAME__, __OPTMESHINPUT__, and __POINTFILENAME__ or __INPUTDATAFILE__ provided. __OPTMESHINPUT__ follows the same scheme as the tRIBS model, option 1 will read in an preexisting mesh defined by .edges, .tri, .nodes, and .z files. Option 8 will read in the .points file and will conduct the triangulation based on the x, y, and z points. MeshBuilder can be run via the command line as follows.:
 
 ```meshBuilder example.in```
 

--- a/src/bListInputData/bListInputData.h
+++ b/src/bListInputData/bListInputData.h
@@ -1,0 +1,351 @@
+// MeshBuilder
+//
+// Copyright (c) 2024. tRIBS Developers
+//
+// See LICENSE file in the project root for full license information.
+
+/***************************************************************************
+**
+**  bListInputData.h: 	Header file for class bListInputData
+**
+**  This class is used to read in lists of Delaunay-triangulated
+**  mesh elements from three user-provided input files, which contain
+**  the nodes, directed edges, and triangles in the mesh, respectively.
+**
+**************************************************************************/
+
+#ifndef BLISTINPUTDATA_H
+#define BLISTINPUTDATA_H
+#define kTimeLineMark ' '
+
+#include "src/Headers/Inclusions.h"
+#include "src/Headers/Definitions.h"
+#include "src/bInOut/bInputFile.h"
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <cstring>
+using namespace std;
+
+//=========================================================================
+//
+//
+//                  Section 1: bListInputData Class Declaration
+//
+//
+//=========================================================================
+
+/**************************************************************************
+**  
+**  class bListInputData()
+**
+**  bListInputData reads an established triangulation from a set of four
+**  files, and stores the data in a series of arrays. The files are:
+**    <name>.nodes  --  node (point) data
+**    <name>.edges  --  directed edge data
+**    <name>.tri    --  triangle data
+**    <name>.z      --  "z" value data (elevation or other)
+**
+**************************************************************************/
+
+template< class bSubNode >
+class bListInputData{
+    //friend class bMesh< bSubNode >; 
+
+public:
+    bListInputData( bInputFile & ); 
+    ~bListInputData();
+    void GetKeyEntry();         // not currently supported
+    void GetFileEntry();        // read data from files
+    int nnodes, nedges, ntri;  	// # nodes, edges, & triangles
+    ifstream nodeinfile;   	// node input file
+    ifstream edgeinfile;   	// edge input file
+    ifstream triinfile;    	// triangle input file
+    ifstream zinfile;      	// "z" input file std::vector
+    std::vector< double > x;      	// node x coords
+    std::vector< double > y;      	// node y coords
+    std::vector< double > z;      	// node z values
+    std::vector< int > edgid;     	// node edge ID #s
+    std::vector< int > boundflag; 	// node boundary codes
+    std::vector< int > orgid;     	// directed edge origin node ID #s
+    std::vector< int > destid;    	// directed edge destination node ID #s
+    std::vector< int > nextid;    	// ID #s of next counter-clockwise edges
+    std::vector< int > p0;     	// IDs of triangle node 0
+    std::vector< int > p1;     	// IDs of triangle node 1
+    std::vector< int > p2;     	// IDs of triangle node 2
+    std::vector< int > e0;     	// IDs triangle clockwise-oriented edge 0
+    std::vector< int > e1;     	// IDs triangle clockwise-oriented edge 1
+    std::vector< int > e2;   	// IDs triangle clockwise-oriented edge 2
+    std::vector< int > t0;     	// IDs of neighboring tri's opposite node 0
+    std::vector< int > t1;     	// IDs of neighboring tri's opposite node 1
+    std::vector< int > t2;     	// IDs of neighboring tri's opposite node 2 
+
+};
+
+#endif
+
+//=========================================================================
+//
+//
+//                  Section 1: bListInputData Constructor and Destructor
+//
+//
+//=========================================================================
+
+/**************************************************************************
+**
+**  bListInputData constructor
+**
+**  The constructor takes an input file and reads from it the base name 
+**  containing the triangulation. It then opens <basename>.nodes,
+**  <basename>.z, <basename>.edges, and <basename>.tri. Assuming the
+**  files are valid, the desired time-slice is read from infile, and
+**  the start of data for that time-slice is sought in each of the four
+**  triangulation files. The arrays are dimensioned as needed, and
+**  GetFileEntry() is called to read the data into the arrays. Note that
+**  the time in each file is identified by a space character preceding it
+**  on the same line.
+**
+**  Modifications for tRIBS simplifies routine by not having to search
+**  through multiple time slices. tRIBS has only one time slice at 
+**  INPUTTIME = 0. Option for CHILD maintained. 
+**
+**************************************************************************/
+
+template< class bSubNode >
+bListInputData< bSubNode >::
+bListInputData( bInputFile &infile )                  
+{
+	int righttime;                   	//flag: found the right time slice
+	double time, intime;             	//current & desired time
+	char basename[80],               	//base name of input files
+		inname[80];                  	//full name of an input file
+	char nodeHeader[kMaxNameLength]; 	//header line read from input file
+	char zHeader[kMaxNameLength]; 	//header line read from input file
+	char edgHeader[kMaxNameLength]; 	//header line read from input file
+	char triHeader[kMaxNameLength]; 	//header line read from input file
+	
+	cout<<"\nCreating bListInputData for reading in existing mesh..."<<endl;
+	
+	// Read base name for triangulation files from infile
+	infile.ReadItem( basename, "INPUTDATAFILE" );
+
+	// Open each of the four files
+	strcpy( inname, basename );
+	strcat( inname, ".nodes" );
+	nodeinfile.open(inname);    	//Node input file pointer
+	
+	strcpy( inname, basename );
+	strcat( inname, ".edges" );
+	edgeinfile.open(inname);   	//Edge input file pointer
+	
+	strcpy( inname, basename );
+	strcat( inname, ".tri" );
+	triinfile.open( inname );   	//Triangle input file pointer
+	
+	strcpy( inname, basename );
+	strcat( inname, ".z" );
+	zinfile.open( inname );     	//Elevations input file pointer
+	
+	// Make sure we found them
+	if( !nodeinfile.good() || !edgeinfile.good() || !triinfile.good()
+		|| !zinfile.good() ){
+		cerr << "Error: I can't find one or more of the following files:\n"
+		<< "\t" << basename << ".nodes\n"
+		<< "\t" << basename << ".edges\n"
+		<< "\t" << basename << ".tri\n"
+		<< "\t" << basename << ".z\n";
+		cerr <<"Unable to open triangulation input file(s).";
+	}
+	
+	// Find out which time slice we want to extract
+	intime = 0;
+	
+	cout<<"\nReading in existing mesh files for input time slice = "<< intime<<": "<<endl;
+	cout<<"'"<< basename << ".nodes'"<<endl;
+	cout<<"'"<< basename << ".edges'"<<endl;
+	cout<<"'"<< basename << ".tri'"<<endl;
+	cout<<"'"<< basename << ".z'"<<endl;
+	
+	
+	// For tRIBS, use INPUTTIME = 0 as flag implying only one mesh
+	// list (nodes, edges, tri, z) per file opened. Will read the
+	// the number of elements directly, followed by the values in
+	// the GetFileEntry() Function.
+	
+	
+	if(intime == 0){
+		nodeinfile >> time;
+		nodeinfile >> nnodes;
+		
+		zinfile >> time;
+		zinfile >> nnodes;
+		
+		edgeinfile >> time;
+		edgeinfile >> nedges;
+		
+		triinfile >> time;
+		triinfile >> ntri;
+	}
+	
+	
+	// Keep the following for CHILD compatibility
+	
+	else{    // Find specified input times in input data files and read # items.
+		
+		//Nodes:
+		righttime = 0;
+		time = 0;
+		while( !( nodeinfile.eof() ) && !righttime ){
+			nodeinfile.getline( nodeHeader, kMaxNameLength );
+			cout<<"nodeheader[0] = "<<nodeHeader[0]<<endl;
+			if( nodeHeader[0] == kTimeLineMark ){
+				nodeinfile.seekg( -nodeinfile.gcount(), ios::cur );
+				nodeinfile >> time;
+				cout << "from node file, time = " << time << endl;
+				cout << "from node file, intime = " <<intime <<endl;
+				if( time == intime ) righttime = 1;
+			}
+		}
+		if( !( nodeinfile.eof() ) ) nodeinfile >> nnodes;
+		else{
+			cerr << "\nCouldn't find the specified input time in the node file\n";
+		}
+		
+		//"z" values:
+		righttime = 0;
+		time = 0;
+		while( !( zinfile.eof() ) && !righttime ){
+			zinfile.getline( zHeader, kMaxNameLength );
+			cout<<"zheader[0] = "<<zHeader[0]<<endl;
+			if( zHeader[0] == kTimeLineMark ){
+				zinfile.seekg( -zinfile.gcount(), ios::cur );
+				zinfile >> time;
+				cout << "from z file, time = " << time << endl;
+				cout << "from z file, intime = " <<intime <<endl;
+				if( time == intime ) righttime = 1;
+			}
+		}
+		if( !( zinfile.eof() ) ) zinfile >> nnodes;
+		else{
+			cerr << "Couldn't find the specified input time in elevation file\n";
+		}
+		
+		//Edges:
+		righttime = 0;
+		time = 0;
+		while( !( edgeinfile.eof() ) && !righttime ){
+			edgeinfile.getline( edgHeader, kMaxNameLength );
+			cout<<"edgheader[0] = "<<edgHeader[0]<<endl;
+			if( edgHeader[0] == kTimeLineMark ){
+				edgeinfile.seekg( -edgeinfile.gcount(), ios::cur );
+				edgeinfile >> time;
+				cout << "from edg file, time = " << time << endl;
+				cout << "from edg file, intime = " <<intime <<endl;
+				if( time == intime ) righttime = 1;
+			}
+		}
+		if( !( edgeinfile.eof() ) ) edgeinfile >> nedges;
+		else{
+			cerr << "Couldn't find the specified input time in the edge file\n";
+		}
+		
+		//Triangles:
+		righttime = 0;
+		time = 0;
+		while( !( triinfile.eof() ) && !righttime ){
+			triinfile.getline( triHeader, kMaxNameLength );
+			cout<<"triheader[0] = "<<triHeader[0]<<endl;
+			if( triHeader[0] == kTimeLineMark ){
+				triinfile.seekg( -triinfile.gcount(), ios::cur );
+				triinfile >> time;
+				cout << "from tri file, time = " << time << endl;
+				cout << "from tri file, intime = " <<intime <<endl;
+				if( time == intime ) righttime = 1;
+			}
+		}
+		if( !( triinfile.eof() ) ) triinfile >> ntri;
+		else{
+			cerr << "Couldn't find the specified input time in the tri file\n";
+		}
+	}
+	
+	// Dimension the arrays 
+	x.resize( nnodes );
+	y.resize( nnodes );
+	z.resize( nnodes );
+	edgid.resize( nnodes );
+	boundflag.resize( nnodes );
+	orgid.resize( nedges );
+	destid.resize( nedges );
+	nextid.resize( nedges );
+	p0.resize( ntri );
+	p1.resize( ntri );
+	p2.resize( ntri );
+	e0.resize( ntri );
+	e1.resize( ntri );
+	e2.resize( ntri );
+	t0.resize( ntri );
+	t1.resize( ntri );
+	t2.resize( ntri );
+	
+	// Read in data from file
+	GetFileEntry();
+	
+	// Close the files
+	nodeinfile.close();
+	edgeinfile.close();
+	triinfile.close();
+	zinfile.close();
+}
+
+template< class bSubNode >
+bListInputData< bSubNode >:: ~bListInputData(){ }
+
+//=========================================================================
+//
+//
+//                  Section 2: bListInputData Functions
+//
+//
+//=========================================================================
+
+/**************************************************************************
+**
+**  bListInputData::GetFileEntry()
+**
+**  Reads node, edge, and triangle data from the four triangulation input
+**  files. Assumes that each files is open and valid and that the current
+**  reading point in each corresponds the start of data for the desired
+**  time-slice.
+**
+**************************************************************************/
+
+template< class bSubNode >
+void bListInputData< bSubNode >::
+GetFileEntry()                 
+{
+	int i;
+	for( i=0; i< nnodes; i++ ){
+		nodeinfile >> x[i] >> y[i] >> edgid[i] >> boundflag[i];
+		zinfile >> z[i];
+	}
+	
+	for( i=0; i<nedges; i++ )
+		edgeinfile >> orgid[i] >> destid[i] >> nextid[i];
+	
+	for( i=0; i< ntri; i++ )
+		triinfile >> p0[i] >> p1[i] >> p2[i] >> t0[i] >> t1[i] >> t2[i] 
+			>> e0[i] >> e1[i] >> e2[i];
+	
+}
+
+//=========================================================================
+//
+//
+//                      End of bListInputData.h
+//
+//
+//=========================================================================
+

--- a/src/bListInputData/bListInputData.h
+++ b/src/bListInputData/bListInputData.h
@@ -107,9 +107,9 @@ public:
 **  the time in each file is identified by a space character preceding it
 **  on the same line.
 **
-**  Modifications for tRIBS simplifies routine by not having to search
-**  through multiple time slices. tRIBS has only one time slice at 
-**  INPUTTIME = 0. Option for CHILD maintained. 
+**  Modifications for MeshBuilder simplifies routine by not having to search
+**  through multiple time slices. MeshBuilder has only one time slice at 
+**  time zero. Option for CHILD not maintained, input time assumed zero. 
 **
 **************************************************************************/
 
@@ -159,10 +159,10 @@ bListInputData( bInputFile &infile )
 		cerr <<"Unable to open triangulation input file(s).";
 	}
 	
-	// Find out which time slice we want to extract
+	// Timeslice hardcoded to 0 as the time funcationaility is not used.
 	intime = 0;
 	
-	cout<<"\nReading in existing mesh files for input time slice = "<< intime<<": "<<endl;
+	cout<<"\nReading in existing mesh files:"<<endl;
 	cout<<"'"<< basename << ".nodes'"<<endl;
 	cout<<"'"<< basename << ".edges'"<<endl;
 	cout<<"'"<< basename << ".tri'"<<endl;

--- a/src/bMesh/bMesh.h
+++ b/src/bMesh/bMesh.h
@@ -27,6 +27,8 @@
 #include "src/bMesh/bTriangulator.h"
 #include "src/bMeshElements/bMeshElements.h"
 #include "src/bInOut/bInputFile.h"
+#include "src/bListInputData/bListInputData.h"
+//#include "src/bList/bList.h"
 
 #ifdef ALPHA_64
   #include <stdlib.h>
@@ -41,6 +43,7 @@
   #include <stdlib.h>
   #include <strings.h>
   #include <list.h>
+  #include <vector>
 #endif
 
 using namespace std;
@@ -77,6 +80,9 @@ public:
    // Calculate counter clockwise edges so that spokes can be eliminated
    void MakeCCWEdges();
 
+   // Creating Mesh from Existing Mesh 
+   void MakeMeshFromInputData(bInputFile& infile);
+
    // Calculate voronoi vertex and areas and save in nodes and edges
    void setVoronoiVertices();
    void CalcVoronoiEdgeLengths();
@@ -109,7 +115,6 @@ protected:
    bTriangle* mSearchOriginTriPtr; 	// triangle to start searches from
 };
 
-
 // DEFAULT CONSTRUCTOR
 template< class bSubNode >
 bMesh< bSubNode >:: bMesh()
@@ -141,6 +146,203 @@ bMesh< bSubNode >::~bMesh()
     triList.erase(triList.begin(), triList.end());
 
     cout << "bMesh Object has been destroyed..." << endl;
+}
+
+//=========================================================================
+//
+//
+//  bMesh::MakeMeshFromInputData()
+//  
+//   Orignal code from tRIBS, tMesh.cpp but major changes to the orignal code 
+//   code were made to get the code working in MeshBuilder. CJC 2025
+//   Constructs tListInputData object and makes mesh from data in that object.
+//                    
+//   Calls: tListInputData( infile ), CheckMeshConsistency()
+//   Inputs: infile -- main input file from which various items are read
+//=========================================================================
+
+template< class bSubNode >
+void bMesh< bSubNode >::MakeMeshFromInputData(bInputFile& infile)
+{
+    bListInputData< bSubNode > input( infile );
+
+    int i;
+    nnodes = input.x.size();
+    nedges = input.orgid.size();
+    ntri = input.p0.size();
+        
+    assert( nnodes > 0 );
+    assert( nedges > 0 );
+    assert( ntri > 0 );
+        
+    // Create the node list by creating a temporary node and iteratively
+    // (1) assigning it values from the input data and (2) inserting it
+    // onto the back of the node list.
+        
+    // --- NODES ---
+    cout << "\nCreating node list..." << endl;
+    // Populate nodeList 
+    for( int i = 0; i < nnodes; i++ ) {
+        bSubNode* tempnode_ptr = new bSubNode(); // <<< USE DEFAULT CONSTRUCTOR
+        // Now set all properties for tempnode_ptr
+        tempnode_ptr->set3DCoords( input.x[i], input.y[i], input.z[i] );
+        tempnode_ptr->setID( i ); // Crucial: 0 to nnodes-1
+        int bound = input.boundflag[i]; // boundflag comes from tListInputData
+        tempnode_ptr->setBoundaryFlag( bound );
+
+        // Use bMeshList's insertion methods
+        if( (bound == kNonBoundary) || (bound == kStream) ) // Use defined constants if available
+            nodeList.insertAtActiveBack( tempnode_ptr );
+        else if( bound == kOpenBoundary )
+            nodeList.insertAtBoundFront( tempnode_ptr );
+        else // kClosedBoundary
+            nodeList.insertAtBack( tempnode_ptr );
+    }
+
+    // Create NodeTable 
+    std::vector<bSubNode*> NodeTable_vec(nnodes, nullptr);
+    for (std::_List_iterator<bSubNode*> it = nodeList.begin(); it != nodeList.end(); ++it) {
+        bSubNode* node_ptr = *it;
+        if (node_ptr && node_ptr->getID() >= 0 && node_ptr->getID() < nnodes) {
+            NodeTable_vec[node_ptr->getID()] = node_ptr;
+        }
+    }
+
+    // --- EDGES ---
+    cout << "\nCreating edge list..." << endl;
+    // Populate edgeList (bMeshList<bEdge*>, i.e., std::list<bEdge*>)
+    int miNextEdgID;
+    for( miNextEdgID = 0; miNextEdgID < nedges; miNextEdgID++ ){ // Iterate for each edge from input
+        bEdge* tempedge_ptr = new bEdge();
+        tempedge_ptr->setID( miNextEdgID ); // ID is 0 to nedges-1, matching input.orgid's implicit index
+
+        bSubNode *nodPtr1 = NodeTable_vec[ input.orgid[miNextEdgID] ]; // Use NodeTable_vec
+        tempedge_ptr->setOriginPtr( nodPtr1 );
+        int obnd = nodPtr1->getBoundaryFlag();
+
+        bSubNode *nodPtr2 = NodeTable_vec[ input.destid[miNextEdgID] ]; // Use NodeTable_vec
+        tempedge_ptr->setDestinationPtr( nodPtr2 );
+        int dbnd = nodPtr2->getBoundaryFlag();
+        
+        // Set flow allowed and insert into edgeList
+        if( obnd == kClosedBoundary || dbnd == kClosedBoundary
+            || (obnd==kOpenBoundary && dbnd==kOpenBoundary) ) {
+            tempedge_ptr->setFlowAllowed( 0 );
+            edgeList.insertAtBack( tempedge_ptr );
+        } else {
+            tempedge_ptr->setFlowAllowed( 1 );
+            edgeList.insertAtActiveBack( tempedge_ptr );
+        }
+    }
+     // The original code incremented miNextEdgID by 2 because it created pairs.
+     // Your tListInputData provides orgid[i], destid[i], nextid[i] for each individual edge 'i'.
+     // So the loop for miNextEdgID should go from 0 to nedges-1.
+
+    // Create EdgeTable (std::vector based)
+    std::vector<bEdge*> EdgeTable_vec(nedges, nullptr);
+    for (std::_List_iterator<bEdge*> it = edgeList.begin(); it != edgeList.end(); ++it) {
+        bEdge* edge_ptr = *it;
+        if (edge_ptr && edge_ptr->getID() >= 0 && edge_ptr->getID() < nedges) {
+            EdgeTable_vec[edge_ptr->getID()] = edge_ptr;
+        }
+    }
+
+    // --- SPOKE LISTS & CCW EDGES ---
+    cout << "\nSetting up spoke lists and CCW edges..." << endl;
+    for (std::_List_iterator<bSubNode*> it = nodeList.begin(); it != nodeList.end(); ++it) {
+        bSubNode* curnode = *it;
+        int node_id = curnode->getID(); // This is 0 to nnodes-1
+
+        // input.edgid[node_id] is the ID of the first spoke for this node
+        // input.nextid[edge_id] is the next CCW edge for 'edge_id'
+        
+        const int first_spoke_id = input.edgid[node_id];
+        if (first_spoke_id < 0 || first_spoke_id >= nedges) { /* error */ continue; }
+
+        bEdge *first_edge_ptr = EdgeTable_vec[first_spoke_id];
+        if (!first_edge_ptr) { /* error */ continue; }
+
+        curnode->setEdg( first_edge_ptr ); // Set first edge
+        // The spoke list in bNode seems to build itself if setEdg and ccw links are correct.
+        // Or, we might need to populate it manually if that's how tMesh did it.
+        // The original MakeMeshFromInputData did:
+        // curnode->insertBackSpokeList( edgPtr );
+        // int ne;
+        // for( ne = input.nextid[e1]; ne != e1; ne = input.nextid[ne] ) {
+        //    bEdge *nextEdgPtr = EdgeTable_vec[ne];
+        //    curnode->insertBackSpokeList( nextEdgPtr );
+        // }
+        // Let's assume bNode::makeCCWEdges() or similar handles full spoke list from first edge + CCW links.
+
+        // If `bNode::insertBackSpokeList` is necessary:
+        curnode->getSpokeListNC().clear(); // Clear any existing spokes
+        bEdge* current_spoke_ptr = first_edge_ptr;
+        int current_spoke_id = first_spoke_id;
+        do {
+            curnode->insertBackSpokeList(current_spoke_ptr);
+            current_spoke_id = input.nextid[current_spoke_id]; // Get next CCW edge ID from .edges file data
+            if (current_spoke_id < 0 || current_spoke_id >= nedges) { /* error, break */ break;}
+            current_spoke_ptr = EdgeTable_vec[current_spoke_id];
+            if (!current_spoke_ptr) { /* error, break */ break; }
+        } while (current_spoke_id != first_spoke_id && curnode->getSpokeListNC().size() < 100); // Safety break
+    }
+
+    // Set CCW edges for each edge
+    for (std::_List_iterator<bEdge*> it = edgeList.begin(); it != edgeList.end(); ++it) {
+        bEdge* curedg = *it;
+        int edge_id = curedg->getID(); // 0 to nedges-1
+        int ccw_neighbor_id = input.nextid[edge_id]; // From .edges file data
+
+        if (ccw_neighbor_id >= 0 && ccw_neighbor_id < nedges) {
+            bEdge* ccwedg_ptr = EdgeTable_vec[ccw_neighbor_id];
+            curedg->setCCWEdg( ccwedg_ptr );
+        } else { /* error: invalid CCW edge ID */ }
+    }
+
+
+    // --- TRIANGLES ---
+    cout << "\nSetting up triangle connectivity..." << endl;
+    // Change triList to std::list<bTriangle*> or bMeshList<bTriangle*>
+    // For now, assuming it's std::list<bTriangle*> as in the original bMesh.h code
+    for (int i = 0; i < ntri; i++ ) {
+        bTriangle* newtri_ptr = new bTriangle();
+        newtri_ptr->setID( i ); // 0 to ntri-1
+        newtri_ptr->setPPtr( 0, NodeTable_vec[ input.p0[i] ] );
+        newtri_ptr->setPPtr( 1, NodeTable_vec[ input.p1[i] ] );
+        newtri_ptr->setPPtr( 2, NodeTable_vec[ input.p2[i] ] );
+        newtri_ptr->setEPtr( 0, EdgeTable_vec[ input.e0[i] ] );
+        newtri_ptr->setEPtr( 1, EdgeTable_vec[ input.e1[i] ] );
+        newtri_ptr->setEPtr( 2, EdgeTable_vec[ input.e2[i] ] );
+        triList.push_back( newtri_ptr ); // If std::list
+        // If bMeshList: triList.insertAtBack(newtri_ptr); or similar
+    }
+
+    // Create TriTable (std::vector based)
+    std::vector<bTriangle*> TriTable_vec(ntri, nullptr);
+    for (std::_List_iterator<bTriangle*> it = triList.begin(); it != triList.end(); ++it) {
+        bTriangle* tri_ptr = *it;
+        if (tri_ptr && tri_ptr->getID() >= 0 && tri_ptr->getID() < ntri) {
+            TriTable_vec[tri_ptr->getID()] = tri_ptr;
+        }
+    }
+    
+    // Set triangle neighbors
+    for (std::_List_iterator<bTriangle*> it = triList.begin(); it != triList.end(); ++it) {
+        bTriangle* ct = *it;
+        if (!ct) continue;
+        int current_tri_id = ct->getID(); // 0 to ntri-1
+
+        bTriangle* nbrtri;
+        nbrtri = (input.t0[current_tri_id] >= 0 && input.t0[current_tri_id] < ntri) ? TriTable_vec[ input.t0[current_tri_id] ] : nullptr;
+        ct->setTPtr( 0, nbrtri );
+        nbrtri = (input.t1[current_tri_id] >= 0 && input.t1[current_tri_id] < ntri) ? TriTable_vec[ input.t1[current_tri_id] ] : nullptr;
+        ct->setTPtr( 1, nbrtri );
+        nbrtri = (input.t2[current_tri_id] >= 0 && input.t2[current_tri_id] < ntri) ? TriTable_vec[ input.t2[current_tri_id] ] : nullptr;
+        ct->setTPtr( 2, nbrtri );
+    }
+
+    cout<<"\nTesting Mesh..."<<endl;
+    CheckMeshConsistency(); 
 }
 
 //=========================================================================

--- a/src/bMesh/bMesh.h
+++ b/src/bMesh/bMesh.h
@@ -28,7 +28,6 @@
 #include "src/bMeshElements/bMeshElements.h"
 #include "src/bInOut/bInputFile.h"
 #include "src/bListInputData/bListInputData.h"
-//#include "src/bList/bList.h"
 
 #ifdef ALPHA_64
   #include <stdlib.h>
@@ -159,6 +158,7 @@ bMesh< bSubNode >::~bMesh()
 //                    
 //   Calls: tListInputData( infile ), CheckMeshConsistency()
 //   Inputs: infile -- main input file from which various items are read
+//
 //=========================================================================
 
 template< class bSubNode >


### PR DESCRIPTION
**Motivation**
Currently, meshbuilder can only generate a mesh from a *.points file. The main tRIBS model, however, has long supported reading mesh data from a pre-generated set of files (.z, .edges, .nodes, .tri).
This PR closes that feature gap, bringing meshbuilder's input capabilities in line with tRIBS. This enhancement provides two key benefits:

1. Workflow Consistency: Users can now use the same mesh files for both tRIBS and MeshBuilder without being restricted to a .points file.
2. Flexibility: It allows users to bring meshes created by external tools and process them with MeshBuilder, as long as they are converted to the tRIBS format first.

**Description of Changes**
- Introduced a new required parameter OPTMESHINPUT in the main input file to control the mesh source.
            - OPTMESHINPUT = 8: The existing behavior (reads from a *.points file).
            - OPTMESHINPUT = 1: The new behavior (reads from *.z, *.edges, *.nodes, and *.tri files).
- Added logic to the mesh reading module to parse these four new file types when OPTMESHINPUT is set to 1.
- When reading mesh files using OPTMESHINPUT = 1 the parameter INPUTDATAFILE is also required in the input file. This is the file path to the four mesh files and the base name.
- Updated input file parsing to make OPTMESHINPUT a mandatory field.